### PR TITLE
Remove download script, tidy up %files and date, tweak instructions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,13 @@ RPM packaging of PROJ.4 for Sailfish
 
 ## Howto build
 
-* Clone this repository
+* Clone this repository with `git clone --recurse-submodules`
 
-* cd into it and run `./download.sh`
-
-* cd into source directory
+* cd into root directory of this repository
 
 * build by running 
 ```
-export SFARCH=armv7hl; mb2 -t SailfishOS-$SFARCH -s ../rpm/proj.spec build
+export SFARCH=armv7hl; mb2 -t SailfishOS-$SFARCH -s rpm/proj.spec build
 ```
 in MER SDK. 
 

--- a/download.sh
+++ b/download.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e
-
-VERSION=4.9.3
-
-wget http://download.osgeo.org/proj/proj-$VERSION.tar.gz
-tar xvf proj-$VERSION.tar.gz

--- a/rpm/proj.spec
+++ b/rpm/proj.spec
@@ -59,7 +59,6 @@ CXXFLAGS="$CXXFLAGS -fPIC"
 %postun -n proj -p /sbin/ldconfig
 
 %files
-%files
 %defattr(-, root, root, 0755)
 %{_libdir}/libproj.so
 %{_libdir}/libproj.so.12
@@ -92,5 +91,5 @@ CXXFLAGS="$CXXFLAGS -fPIC"
 %{_mandir}/man3/pj_init.3.gz
 
 %changelog
-* Thu Apr 10 2017 rinigus <rinigus.git@gmail.com> - 1.2.76
+* Mon Apr 10 2017 rinigus <rinigus.git@gmail.com> - 1.2.76
 - initial packaging release for SFOS


### PR DESCRIPTION
1. Removed redundant download script and attached instructions
2. Removed duplicate %files
3. Fixed weekday in rpm changelog
4. Tweaked instructions in README as you don't need to be in proj.4 to
   build (keeps things better organised)